### PR TITLE
Update to Vapor 2

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -2,112 +2,100 @@
   "autoPin": true,
   "pins": [
     {
-      "package": "CLibreSSL",
+      "package": "BCrypt",
       "reason": null,
-      "repositoryURL": "https://github.com/vapor/clibressl.git",
+      "repositoryURL": "https://github.com/vapor/bcrypt.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Bits",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/bits.git",
       "version": "1.0.0"
     },
     {
       "package": "Console",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/console.git",
-      "version": "1.0.2"
+      "version": "2.0.0"
     },
     {
       "package": "Core",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/core.git",
-      "version": "1.1.1"
+      "version": "2.0.0"
     },
     {
       "package": "Crypto",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/crypto.git",
-      "version": "1.1.0"
+      "version": "2.0.0"
+    },
+    {
+      "package": "CTLS",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/ctls.git",
+      "version": "1.0.0"
+    },
+    {
+      "package": "Debugging",
+      "reason": null,
+      "repositoryURL": "https://github.com/vapor/debugging.git",
+      "version": "1.0.0"
     },
     {
       "package": "Engine",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/engine.git",
-      "version": "1.3.12"
-    },
-    {
-      "package": "Fluent",
-      "reason": null,
-      "repositoryURL": "https://github.com/vapor/fluent.git",
-      "version": "1.4.3"
-    },
-    {
-      "package": "Jay",
-      "reason": null,
-      "repositoryURL": "https://github.com/DanToml/Jay.git",
-      "version": "1.0.1"
+      "version": "2.0.0"
     },
     {
       "package": "JSON",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/json.git",
-      "version": "1.0.6"
-    },
-    {
-      "package": "Leaf",
-      "reason": null,
-      "repositoryURL": "https://github.com/vapor/leaf.git",
-      "version": "1.0.7"
+      "version": "2.0.0"
     },
     {
       "package": "Multipart",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/multipart.git",
-      "version": "1.0.3"
+      "version": "2.0.0"
     },
     {
       "package": "Node",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/node.git",
-      "version": "1.0.1"
+      "version": "2.0.0"
     },
     {
-      "package": "PathIndexable",
+      "package": "Random",
       "reason": null,
-      "repositoryURL": "https://github.com/vapor/path-indexable.git",
+      "repositoryURL": "https://github.com/vapor/random.git",
       "version": "1.0.0"
-    },
-    {
-      "package": "Polymorphic",
-      "reason": null,
-      "repositoryURL": "https://github.com/vapor/polymorphic.git",
-      "version": "1.0.1"
     },
     {
       "package": "Routing",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/routing.git",
-      "version": "1.1.0"
+      "version": "2.0.0"
     },
     {
-      "package": "Socks",
+      "package": "Sockets",
       "reason": null,
-      "repositoryURL": "https://github.com/vapor/socks.git",
-      "version": "1.2.7"
+      "repositoryURL": "https://github.com/vapor/sockets.git",
+      "version": "2.0.0"
     },
     {
       "package": "TLS",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/tls.git",
-      "version": "1.1.2"
-    },
-    {
-      "package": "Turnstile",
-      "reason": null,
-      "repositoryURL": "https://github.com/stormpath/Turnstile.git",
-      "version": "1.0.6"
+      "version": "2.0.0"
     },
     {
       "package": "Vapor",
       "reason": null,
       "repositoryURL": "https://github.com/vapor/vapor.git",
-      "version": "1.5.14"
+      "version": "2.0.0"
     }
   ],
   "version": 1

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,6 @@ import PackageDescription
 let package = Package(
     name: "wkhtmltopdf",
     dependencies: [
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1, minor: 5),
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 2),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # wkhtmltopdf
 
 ![Swift](http://img.shields.io/badge/swift-3.1-brightgreen.svg)
-![Vapor](http://img.shields.io/badge/vapor-1.5-brightgreen.svg)
+![Vapor](http://img.shields.io/badge/vapor-2.0-brightgreen.svg)
 ![Travis](https://travis-ci.org/vapor-community/wkhtmltopdf.svg?branch=master)
 
-Vapor library for converting HTML (Leaf or otherwise) into PDF files using
+Vapor 2 library for converting HTML (Leaf or otherwise) into PDF files using
 [wkhtmltopdf](http://wkhtmltopdf.org/).
 
 ## 📘 Overview
@@ -37,7 +37,7 @@ document.pages = [page1, page2, page3]
 // Render to a PDF
 let pdf = try document.generatePDF()
 // Now you can return the PDF as a response, if you want
-let response = Response(status: .ok, body: .data(try pdf.makeBytes()))
+let response = Response(status: .ok, body: .data(pdf))
 response.headers["Content-Type"] = "application/pdf"
 return response
 ```
@@ -66,6 +66,13 @@ Here is a worked example Leaf file which loads CSS and images. It uses the
   </body>
 </html>
 ```
+
+### Zoom calibration
+
+Across different platforms, `wkhtmltopdf` can require different zoom levels to
+ensure that 1 mm in HTML equals 1 mm in PDF. The default zoom level is `1.3`,
+which has been found to work well on Linux, but if you need a different zoom
+level set the static property `Document.zoom` before doing any rendering.
 
 ### Why Pages?
 

--- a/Sources/wkhtmltopdf/Document.swift
+++ b/Sources/wkhtmltopdf/Document.swift
@@ -1,5 +1,8 @@
 public class Document {
 
+  // This may need changing across different platforms and deployments.
+  static var zoom: String = "1.3"
+
   let topMargin: Int
   let rightMargin: Int
   let bottomMargin: Int

--- a/Sources/wkhtmltopdf/Page+View.swift
+++ b/Sources/wkhtmltopdf/Page+View.swift
@@ -4,10 +4,10 @@ extension Page {
 
   public init(_ drop: Droplet, view path: String, _ context: Node? = nil) throws {
     var ctx = context ?? Node.object([:])
-    ctx["workDir"] = drop.workDir.makeNode()
-    ctx["publicDir"] = (drop.workDir + "Public/").makeNode()
+    ctx["workDir"] = drop.config.workDir.makeNode(in: nil)
+    ctx["publicDir"] = (drop.config.workDir + "Public/").makeNode(in: nil)
     let view = try drop.view.make(path, ctx)
-    self.init(view.data.string)
+    self.init(view.data)
   }
 
 }

--- a/Sources/wkhtmltopdf/Page.swift
+++ b/Sources/wkhtmltopdf/Page.swift
@@ -1,9 +1,15 @@
+import Bits
+
 public struct Page {
 
-  let content: String
+  let content: Bytes
+
+  public init(_ content: Bytes) {
+    self.content = content
+  }
 
   public init(_ content: String) {
-    self.content = content
+    self.content = content.makeBytes()
   }
 
 }

--- a/Tests/wkhtmltopdfTests/wkhtmltopdfTests.swift
+++ b/Tests/wkhtmltopdfTests/wkhtmltopdfTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import wkhtmltopdf
+import Core
 
 class wkhtmltopdfTests: XCTestCase {
   static var allTests = [
@@ -10,6 +11,12 @@ class wkhtmltopdfTests: XCTestCase {
     let document = Document(margins: 15)
     let page1 = Page("<p>Page from direct HTML</p>")
     document.pages = [page1]
-    _ = try document.generatePDF()
+    let data = try document.generatePDF()
+    // Cop-out test, just ensuring that the returned data is something
+    XCTAssert(data.count > 50)
+    // Visual test
+    let fm = DataFile(workDir: "/tmp/vapor-wkhtmltopdf")
+    try fm.write(data, to: "/tmp/vapor-wkhtmltopdf/testOutput.pdf")
+    print("Test output PDF can be viewed at /tmp/vapor-wkhtmltopdf/testOutput.pdf")
   }
 }


### PR DESCRIPTION
Use `Bytes` instead of `Data` for public facing API; allow a customisable zoom level.