### PR TITLE
Allow specifying the launch path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Add the following in your `Package.swift` file
 
 ## 📘 Overview
 
-First, install [wkhtmltopdf](http://wkhtmltopdf.org/downloads.html). This
-library is tested on version 0.12.4. Specify the location of `wkhtmltopdf` in the `Document` initialiser. The default is `/usr/local/bin/wkhtmltopdf`. Run it to ensure it and any dependencies are
-installed correctly.
+First, install [wkhtmltopdf](http://wkhtmltopdf.org/downloads.html). This 
+library is tested on version 0.12.4. Specify the location of `wkhtmltopdf` 
+in the `Document` initialiser. The default is `/usr/local/bin/wkhtmltopdf`. 
+Run it to ensure it and any dependencies are installed correctly.
 
 To create a PDF, create and configure a `Document`, add one or more `Page`s,
 and then call `generatePDF(on: Request)`. Here is a full example:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Add the following in your `Package.swift` file
 ## 📘 Overview
 
 First, install [wkhtmltopdf](http://wkhtmltopdf.org/downloads.html). This
-library is tested on version 0.12.4. Your binary should be installed at
-`/usr/local/bin/wkhtmltopdf`; run it to ensure it and any dependencies are
+library is tested on version 0.12.4. Specify the location of `wkhtmltopdf` in the `Document` initialiser. The default is `/usr/local/bin/wkhtmltopdf`. Run it to ensure it and any dependencies are
 installed correctly.
 
 To create a PDF, create and configure a `Document`, add one or more `Page`s,

--- a/Sources/wkhtmltopdf/Document+Generate.swift
+++ b/Sources/wkhtmltopdf/Document+Generate.swift
@@ -36,7 +36,7 @@ extension Document {
             // Call wkhtmltopdf and retrieve the result data
             let wk = Process()
             let stdout = Pipe()
-            wk.launchPath = "/usr/local/bin/wkhtmltopdf"
+            wk.launchPath = self.launchPath
             wk.arguments = wkArgs
             wk.arguments?.append("-") // output to stdout
             wk.standardOutput = stdout

--- a/Sources/wkhtmltopdf/Document.swift
+++ b/Sources/wkhtmltopdf/Document.swift
@@ -5,18 +5,20 @@ public class Document {
     let rightMargin: Int
     let bottomMargin: Int
     let leftMargin: Int
+    let launchPath: String
 
     let paperSize: String
 
     public var pages: [Page] = []
     
-    public init(size: String = "A4", zoom: String? = nil, margins all: Int? = nil, top: Int? = nil, right: Int? = nil, bottom: Int? = nil, left: Int? = nil) {
+    public init(size: String = "A4", zoom: String? = nil, margins all: Int? = nil, top: Int? = nil, right: Int? = nil, bottom: Int? = nil, left: Int? = nil, path: String = "/usr/local/bin/wkhtmltopdf") {
         self.zoom = zoom ?? "1.3"
         paperSize = size
         topMargin = all ?? top ?? 20
         rightMargin = all ?? right ?? 20
         bottomMargin = all ?? bottom ?? 20
         leftMargin = all ?? left ?? 20
+        launchPath = path
     }
 
 }


### PR DESCRIPTION
The launch path isn't always under the user's control. For instance on Heroku it would be `/app/bin/wkhtmltopdf`