### PR TITLE
Upgrade to NIO 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ Packages
 .build
 .DS_Store
 *.xcodeproj
-
+Package.resolved
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -6,20 +6,22 @@ let package = Package(
     products: [
         .library(
             name: "wkhtmltopdf",
-            targets: ["wkhtmltopdf"]),
+            targets: ["wkhtmltopdf"]
+        ),
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
-        .package(url: "https://github.com/vapor/service.git", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
     ],
     targets: [
         .target(
             name: "wkhtmltopdf",
             dependencies: [
-                "Service"
-            ]),
+                .product(name: "NIO", package: "swift-nio")
+            ]
+        ),
         .testTarget(
             name: "wkhtmltopdfTests",
-            dependencies: ["wkhtmltopdf", "Vapor"]),
+            dependencies: ["wkhtmltopdf"]
+        ),
     ]
 )

--- a/Sources/wkhtmltopdf/Document+Generate.swift
+++ b/Sources/wkhtmltopdf/Document+Generate.swift
@@ -1,16 +1,16 @@
 import Foundation
-import Service
+import NIO
 
 extension Document {
 
-    public func generatePDF(on container: Container) throws -> Future<Data> {
-        let sharedThreadPool = try container.make(BlockingIOThreadPool.self)
-
-        return sharedThreadPool.runIfActive(eventLoop: container.eventLoop) { () -> Data in
+    public func generatePDF(on eventLoop: EventLoop) throws -> EventLoopFuture<Data> {
+        return NIOThreadPool(numberOfThreads: 1).runIfActive(eventLoop: eventLoop) {
             let fileManager = FileManager.default
+
             // Create the temp folder if it doesn't already exist
             let workDir = "/tmp/vapor-wkhtmltopdf"
             try fileManager.createDirectory(atPath: workDir, withIntermediateDirectories: true)
+
             // Save input pages to temp files, and build up args to wkhtmltopdf
             var wkArgs: [String] = [
                 "--zoom", self.zoom,

--- a/Sources/wkhtmltopdf/Document+Generate.swift
+++ b/Sources/wkhtmltopdf/Document+Generate.swift
@@ -3,8 +3,8 @@ import NIO
 
 extension Document {
 
-    public func generatePDF(on eventLoop: EventLoop) throws -> EventLoopFuture<Data> {
-        return NIOThreadPool(numberOfThreads: 1).runIfActive(eventLoop: eventLoop) {
+    public func generatePDF(on threadPool: NIOThreadPool = NIOThreadPool(numberOfThreads: 1), eventLoop: EventLoop) throws -> EventLoopFuture<Data> {
+        return threadPool.runIfActive(eventLoop: eventLoop) {
             let fileManager = FileManager.default
 
             // Create the temp folder if it doesn't already exist


### PR DESCRIPTION
Was going to update this package to Vapor 4, then realized the Vapor dependency isn't really necessary. So this now just depends on NIO 2.

However I haven't worked directly with NIO before so I'm looking for feedback. 

- Is `NIOThreadPool(numberOfThreads: 1).runIfActive(eventLoop: eventLoop)` the right way to replace what was there?
- Also the unit test is failing with `caught error: "ioOnClosedChannel"` and I'm not sure wether my change to the library or tests is what's causing that.