### PR TITLE
Fix for Process.run() fails with "Bad file descriptor" and Swift 5.8

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(

--- a/Sources/wkhtmltopdf/Document+Generate.swift
+++ b/Sources/wkhtmltopdf/Document+Generate.swift
@@ -40,14 +40,15 @@ extension Document {
                 // Call wkhtmltopdf and retrieve the result data
                 let wk = Process()
                 let stdout = Pipe()
-                wk.launchPath = self.launchPath
+                wk.executableURL = URL(fileURLWithPath: self.launchPath)
                 wk.arguments = wkArgs
                 wk.arguments?.append("-") // output to stdout
                 wk.standardOutput = stdout
-                wk.launch()
+                try wk.run()
                 
                 let pdf = stdout.fileHandleForReading.readDataToEndOfFile()
                 continuation.resume(returning: pdf)
+                try stdout.fileHandleForReading.close()
             }.flatMapErrorThrowing { err in
                 continuation.resume(throwing: err)
                 return

--- a/Tests/wkhtmltopdfTests/wkhtmltopdfTests.swift
+++ b/Tests/wkhtmltopdfTests/wkhtmltopdfTests.swift
@@ -28,7 +28,7 @@ class wkhtmltopdfTests: XCTestCase {
         let threadPool = NIOThreadPool(numberOfThreads: 1)
         threadPool.start()
         let data = try await document.generatePDF(on: threadPool, eventLoop: eventLoop)
-        try threadPool.syncShutdownGracefully()
+        try await threadPool.shutdownGracefully()
         // Cop-out test, just ensuring that the returned data is something
         XCTAssert(data.count > 50)
         // Visual test


### PR DESCRIPTION
Small fix for `Pipe()` error when calling process multiple times and obtain `Bad file descriptor` error commented here: https://github.com/apple/swift/issues/57827

Also update swift version to 5.8 and updated `Process()`deprecated methods. 